### PR TITLE
Remove platform dependent library dependency

### DIFF
--- a/osx/build.sh
+++ b/osx/build.sh
@@ -18,16 +18,17 @@ pushd rust
 popd
 
 pushd cargo
+export OPENSSL_STATIC=1
 cargo build --release
 popd
 
 # Copy build products
-mkdir -p deploy
+mkdir -p deploy/bin
 cp version.md deploy
 cp -rf rust/build/x86_64-apple-darwin/stage1/ deploy
-cp cargo/target/release/cargo deploy/bin
+cp cargo/target/release/cargo deploy/bin/
 
 # Needed by xargo
-mkdir deploy/lib/rustlib/x86_64-apple-darwin/bin
+mkdir -p deploy/lib/rustlib/x86_64-apple-darwin/bin
 
 tar -C deploy -jcf solana-rust-bpf-osx.tar.bz2 .


### PR DESCRIPTION
cargo contained a dependency on openssl libraries that may not be consistent between machines.  Link them in statically